### PR TITLE
Changed the file-format for push and pull [DEV-701]

### DIFF
--- a/localize/commands.py
+++ b/localize/commands.py
@@ -144,6 +144,4 @@ def check_and_return_lang_format(filename, type):
   if filename.count('.') != 1:                      # checking filename, shoud be '<lang>.<format>', for example ru.json, es.csv
     sys.exit(Fore.RED + "Wrong filename for '" + type + "' type, target file have to has the following file format '<language>.<format>', for example ru.json" + Style.RESET_ALL)
   splitted_filename = filename.split('.')           # splitting filename by dot
-  print splitted_filename
   return splitted_filename[0],splitted_filename[1]  # returning language and format
-

--- a/localize/commands.py
+++ b/localize/commands.py
@@ -31,10 +31,10 @@ def config():
       token = token
     ),
     push = dict(
-      sources = [dict(file = '/full/path/to/your/file.language.format')]
+      sources = [dict(file = '/full/path/to/your/language_code.format_extension')]
     ),
     pull = dict(
-      targets = [dict(file = '/full/path/to/your/file.language.format')]
+      targets = [dict(file = '/full/path/to/your/language_code.format_extension')]
     )
   )
 
@@ -141,7 +141,9 @@ def pull(conf):
     sys.exit(Fore.GREEN + 'Successfully pulled ' + str(len(conf['pull']['targets'])) + ' file(s) to Localize!' + Style.RESET_ALL)
 
 def check_and_return_lang_format(filename, type):
-  if filename.count('.') != 2:                      # checking filename, shoud be '<name>.<lang>.<format>', for example project_name.ru.json
-    sys.exit(Fore.RED + "Wrong filename for '" + type + "' type, target file have to has the following file format '<name>.<language>.<format>', for example project_name.ru.json" + Style.RESET_ALL)
+  if filename.count('.') != 1:                      # checking filename, shoud be '<lang>.<format>', for example ru.json, es.csv
+    sys.exit(Fore.RED + "Wrong filename for '" + type + "' type, target file have to has the following file format '<language>.<format>', for example ru.json" + Style.RESET_ALL)
   splitted_filename = filename.split('.')           # splitting filename by dot
-  return splitted_filename[1],splitted_filename[2]  # returning language and format
+  print splitted_filename
+  return splitted_filename[0],splitted_filename[1]  # returning language and format
+


### PR DESCRIPTION
*Jira reference: [DEV-701]*

## Purpose
  - changed the format type for push and pull which is prepopulated in config.yml
  - changed the validation part for the push and pull file format


**Testing steps**
- Install the locaize-cli.
- Run localize config , add the projectKey and API token , which generates the .localize/config.yml file in the home folder.
- Add dev: true under api: in the config.yml file
**To Test Push Command**
- Create a file in the format - language_code.format_extension with phrases to import and include the file path in the config.yml  file to push -> sources key
- Run localize push command and check if the newly imported phrases are added in the localize application under the project corresponding to the projectKey
**To Test Pull Command**
- Similary, create another file in the format - language_code.format_extension and add it in under the pull -> targets key
- Run localize pull and test if the phrases having 'active-translations' are exported to that file.

---
- [x] **Work in progress**

- [x] **Awaiting peer review**


- [ ] **Ready for production**

[DEV-701]: https://shapesuite.atlassian.net/jira/software/projects/DEV/boards/5?assignee=5e3c5a2c3f647d0c99d80b02&selectedIssue=DEV-701