### PR TITLE
Add support for new Android / IOS formats to the CLI[DEV-1213]

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2020-08-07
+## Added
+- Updated to support Android, iOS, and new formats [#18](https://github.com/Localize/localize-cli/pull/18).
+
 ## [1.0.1] - 2020-04-22
 ## Added
 - Attempting to add in long description [#15](https://github.com/Localize/localize-cli/pull/15).

--- a/localize/commands.py
+++ b/localize/commands.py
@@ -60,7 +60,7 @@ def push(conf):
     url = get_url(conf)
     headers={ 'Authorization': 'Bearer ' + conf['api']['token'] }
 
-    # Use the file extension to guess the language and format
+    # Use the file extension to guess the language
     base = os.path.basename(source['file'])
     language = check_and_return_lang_format(base, 'push')     # refactoring, extracting duplicate code into method
 
@@ -117,13 +117,9 @@ def pull(conf):
     }
 
     file = target.values()[0]
-    # Use the file extension to guess the language and format
-    # print('target' + target['file'])
-    # base=os.path.basename(file)
-    # print('base' + base)
+
+    # Use the key as the language
     language = target.keys()[0]
-    # language = check_and_return_lang_format(base, 'pull')        # refactoring, extracting duplicate code into method
-    # format = target['file'].split(',')[1]
 
     data={
       'language': language,
@@ -159,7 +155,7 @@ def pull(conf):
     sys.exit(Fore.GREEN + 'Successfully pulled ' + str(len(conf['pull']['targets'])-skip) + ' file(s) to Localize!' + Style.RESET_ALL)
 
 def check_and_return_lang_format(filename, type):
-  # if filename.count('.') != 1:                      # checking filename, shoud be '<lang>.<format>', for example ru.json, es.csv
-    # sys.exit(Fore.RED + "Wrong filename for '" + type + "' type, target file have to has the following file format '<language>.<format>', for example ru.json" + Style.RESET_ALL)
+  if filename.count('.') != 1:                      # checking filename, shoud be '<lang>.<format>', for example ru.json, es.csv
+    sys.exit(Fore.RED + "Wrong filename for '" + type + "' type, target file have to has the following file format '<language>.<format>', for example ru.json" + Style.RESET_ALL)
   splitted_filename = filename.split('.')           # splitting filename by dot
   return splitted_filename[0]  # returning language and format

--- a/localize/commands.py
+++ b/localize/commands.py
@@ -158,4 +158,4 @@ def check_and_return_lang_format(filename, type):
   if filename.count('.') != 1:                      # checking filename, shoud be '<lang>.<format>', for example ru.json, es.csv
     sys.exit(Fore.RED + "Wrong filename for '" + type + "' type, target file have to has the following file format '<language>.<format>', for example ru.json" + Style.RESET_ALL)
   splitted_filename = filename.split('.')           # splitting filename by dot
-  return splitted_filename[0]  # returning language and format
+  return splitted_filename[0]  # returning language

--- a/localize/commands.py
+++ b/localize/commands.py
@@ -113,7 +113,7 @@ def pull(conf):
     url = get_url(conf)
     headers={
       'Content-Type': 'application/json',
-      'Authorization': 'Bearer ' + conf['api']['token'] 
+      'Authorization': 'Bearer ' + conf['api']['token']
     }
 
     file = target.values()[0]
@@ -140,7 +140,7 @@ def pull(conf):
       # Swap put the content of the file with the data
       try:
         with open(file, 'wb') as file:
-          for chunk in r.iter_content(chunk_size=1024): 
+          for chunk in r.iter_content(chunk_size=1024):
             if chunk: # filter out keep-alive new chunks
               file.write(chunk)
       except IOError:
@@ -152,7 +152,7 @@ def pull(conf):
     for error in errors:
       print(Fore.RED + error + Style.RESET_ALL)
   else:
-    sys.exit(Fore.GREEN + 'Successfully pulled ' + str(len(conf['pull']['targets'])-skip) + ' file(s) to Localize!' + Style.RESET_ALL)
+    sys.exit(Fore.GREEN + 'Successfully pulled ' + str(len(conf['pull']['targets'])-skip) + ' file(s) from Localize!' + Style.RESET_ALL)
 
 def check_and_return_lang_format(filename, type):
   if filename.count('.') != 1:                      # checking filename, shoud be '<lang>.<format>', for example ru.json, es.csv

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 setup(
   name="localize",
-  version="1.0.2",
+  version="1.0.3",
   author='Localize',
   author_email='support@localizejs.com',
   url='https://help.localizejs.com/docs/localize-cli',


### PR DESCRIPTION
*Jira reference: [DEV-1213]*

## Purpose
  - Add support for new Android / IOS formats to the CLI


**Testing steps**
- Install the locaize-cli.
- Run localize config , add the projectKey and API token , which generates the .localize/config.yml file in the home folder.
- Add dev: true under api: in the config.yml file

**To Test Push Command**
- Create a file in the format - language_code.extension with phrases to import and include the file path in the config.yml file to push -> sources key and updated the format field.
- Run localize push command and check if the newly imported phrases are added in the localize application under the project corresponding to the projectKey

**To Test Pull Command**
- Similary, create another file in the format - file_name.format_extension and add it in under the pull -> targets key and update the format.
- Run localize pull and test if the phrases having 'active-translations' are exported to that file.
- Check if an error message displays that says "Skipping import of Dutch. No target file path in the localize CLI config.yml" if there isn’t a corresponding target file path for that language, ignore that language for the pull/push.
---
- [x] **Work in progress**

- [x] **Awaiting peer review**


- [x] **Ready for production**