### PR TITLE
Added support for optional file formats [PBI-847]

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2020-10-20
+## Added
+- Added support for optional file formats [#18](https://google.com).
+
 ## [1.0.3] - 2020-08-07
 ## Added
 - Updated to support Android, iOS, and new formats [#18](https://github.com/Localize/localize-cli/pull/18).

--- a/localize/commands.py
+++ b/localize/commands.py
@@ -54,11 +54,15 @@ def config():
 
 def push(conf):
   errors = []
-  format = conf['format']
   skip = 0
   for source in conf['push']['sources']:
     url = get_url(conf)
     headers={ 'Authorization': 'Bearer ' + conf['api']['token'] }
+
+    if 'format' in source:
+      format = source['format']
+    else:
+      format = conf['format']
 
     # Use the file extension to guess the language
     base = os.path.basename(source['file'])
@@ -103,7 +107,6 @@ def pull(conf):
   if not 'targets' in conf['pull']:
     sys.exit(Fore.RED + 'Could not find any targets to pull. Please make sure your configuration is formed correctly.' + Style.RESET_ALL)
 
-  format = conf['format']
   skip = 0
 
   for target in conf['pull']['targets']:
@@ -115,6 +118,11 @@ def pull(conf):
       'Content-Type': 'application/json',
       'Authorization': 'Bearer ' + conf['api']['token']
     }
+
+    if 'format' in target:
+      format = target['format']
+    else:
+      format = conf['format']
 
     file = target.values()[0]
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 setup(
   name="localize",
-  version="1.0.5",
+  version="1.0.6",
   author='Localize',
   author_email='support@localizejs.com',
   url='https://help.localizejs.com/docs/localize-cli',


### PR DESCRIPTION
As a Localize user I would like to be able to use the CLI to pull and push multiple files and file types with a single push/pull command so that I can bulk upload different file types. This would be especially useful for projects that require multiple file types such as Localizable.strings and Localizable.stringsdict.

Currently we can push and pull multiple files without issue.

Update the config file so that you can optionally specify a format for each “file”:

`api:`
 `project: vajARfBCBkXXn`
  `token: c4ebae64a41c81cc800784b9b5a2418f`
`format: ANDROID_XML`
`pull:`
  `targets:`
  `- zh: /Users/jamesbinns/Documents/zh.xml`
  `- fr: /Users/jamesbinns/Documents/fr.strings`
    `format: IOS_STRINGS`
`push:`
  `sources:`
  `- file: /Users/jamesbinns/Downloads/en.json`
    `format: SIMPLE_JSON`
  `- file: /Users/jamesbinns/Documents/Jamie/en.xml`

If no format is specified for a file, use the default format specified.