### PR TITLE
Added support for type in export/export

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2021-02-03
+## Added
+- Added support type (phrase or glossary) [#20](https://github.com/Localize/localize-cli/pull/20).
+
 ## [1.0.6] - 2020-10-20
 ## Added
-- Added support for optional file formats [#19](https://google.com).
+- Added support for optional file formats [#19](https://github.com/Localize/localize-cli/pull/19).
 
 ## [1.0.3] - 2020-08-07
 ## Added

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.7] - 2021-02-03
 ## Added
-- Added support type (phrase or glossary) [#20](https://github.com/Localize/localize-cli/pull/20).
+- Added support for type (phrase or glossary) [#20](https://github.com/Localize/localize-cli/pull/20).
 
 ## [1.0.6] - 2020-10-20
 ## Added

--- a/localize/commands.py
+++ b/localize/commands.py
@@ -55,10 +55,18 @@ def config():
 def push(conf):
   errors = []
   skip = 0
+
+  # Assume pushing phrases unless specified in config_file
+  if 'type' in conf:
+    type = conf['type']
+  else:
+    type = 'phrase'
+
   for source in conf['push']['sources']:
     url = get_url(conf)
     headers={ 'Authorization': 'Bearer ' + conf['api']['token'] }
 
+    #
     if 'format' in source:
       format = source['format']
     else:
@@ -80,6 +88,7 @@ def push(conf):
 
     data={
       'language': language,
+      'type': type,
       'format': format.replace('yml','yaml').upper()  # replacing 'yml' file format to 'yaml'
     }
 
@@ -109,6 +118,12 @@ def pull(conf):
 
   skip = 0
 
+  # Assume pulling phrases unless specified in config_file
+  if 'type' in conf:
+    type = conf['type']
+  else:
+    type = 'phrase'
+
   for target in conf['pull']['targets']:
     if not target:
       sys.exit(Fore.RED + 'Could not find target.' + Style.RESET_ALL)
@@ -131,6 +146,7 @@ def pull(conf):
 
     data={
       'language': language,
+      'type': type,
       'format': format.replace('yml','yaml').upper(),    # replacing 'yml' file format to 'yaml
       'filter': 'has-active-translations'
     }

--- a/localize/commands.py
+++ b/localize/commands.py
@@ -66,7 +66,6 @@ def push(conf):
     url = get_url(conf)
     headers={ 'Authorization': 'Bearer ' + conf['api']['token'] }
 
-    #
     if 'format' in source:
       format = source['format']
     else:


### PR DESCRIPTION
This PR adds support for the `type` parameter since the REST API requires it for import and exposes it for export. This is not a required field in the config file since we default to `phrase` by default. The documentation will cover it but it will not be part of the config.