### PR TITLE
Added support for origin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.0.8] - 2021-02-03
+## Added
+- Added support for import origin [#21](https://github.com/Localize/localize-cli/pull/21).
+
 ## [1.0.7] - 2021-02-03
 ## Added
 - Added support for type (phrase or glossary) [#20](https://github.com/Localize/localize-cli/pull/20).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.0.8] - 2021-02-03
+## [1.0.8] - 2021-02-16
 ## Added
 - Added support for import origin [#21](https://github.com/Localize/localize-cli/pull/21).
 

--- a/localize/commands.py
+++ b/localize/commands.py
@@ -88,6 +88,7 @@ def push(conf):
     data={
       'language': language,
       'type': type,
+      'origin': 'cli',
       'format': format.replace('yml','yaml').upper()  # replacing 'yml' file format to 'yaml'
     }
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 setup(
   name="localize",
-  version="1.0.7",
+  version="1.0.8",
   author='Localize',
   author_email='support@localizejs.com',
   url='https://help.localizejs.com/docs/localize-cli',


### PR DESCRIPTION
This PR adds the `origin` field onto the `push` directive which will set the import history origin as `cli`.