### PR TITLE
Tarball didn't compile for v1.1.1, so bumping again and redeploying

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2021-07-29
+## Added
+- Bumped version due to tarball not compiling [#28](https://github.com/Localize/localize-cli/pull/28).
+
 ## [1.1.0] - 2021-07-29
 ## Added
 - Upgrade python to 3.9.5 [#26](https://github.com/Localize/localize-cli/pull/26).

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 setup(
   name="localize",
-  version="1.1.0",
+  version="1.1.2",
   author='Localize',
   author_email='support@localizejs.com',
   url='https://help.localizejs.com/docs/localize-cli',


### PR DESCRIPTION
Already redeployed, this is to store the version number within `master`: https://pypi.org/project/localize/1.1.2/