### PR TITLE
Replace sys.exit in push[DEV-4671]

### DIFF
--- a/localize/commands.py
+++ b/localize/commands.py
@@ -125,7 +125,7 @@ def push(conf, profile):
     for error in errors:
       print(Fore.RED+error+Style.RESET_ALL)
   else:
-    sys.exit(Fore.GREEN + 'Successfully pushed ' + str(len(conf['push']['sources'])-skip) + ' file(s) to Localize!' + Style.RESET_ALL)
+    print(Fore.GREEN + 'Successfully pushed ' + str(len(conf['push']['sources'])-skip) + ' file(s) to Localize!' + Style.RESET_ALL)
 
 def pull(conf, profile):
   errors = []


### PR DESCRIPTION
Jira reference: DEV-4671

## Description

To replace sys.exit() with print statement to prevent the `localize push && localize pull` from being stopped midway.

## Testing steps

- Test if localize push works as expected.